### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Project that fetches data from Alpha Vantage, and other data providers, and allo
 
 
 ### How to use
-Locate the file ```api.properties``` add they api keys for `AlphaVantage` and `Polygon`, the both provide free API keys.
+Locate the file ```api.properties``` add they api keys for `AlphaVantage` and `Polygon`, they both provide free API keys.
 ```
 alpha_vantage_api=[ YOUR KEY FROM ALPHAVANTAGE GOES HERE ]
 polygon_api=[ YOUR KEY FROM POLYGON GOES HERE ]


### PR DESCRIPTION
### Problem
Change the to they

### Reason
Typo in readme

### Solution
Change the wording from the to they

### Result
"they both provide free API keys."